### PR TITLE
Note about self service resources and snapshot

### DIFF
--- a/docs/self_service.md
+++ b/docs/self_service.md
@@ -36,6 +36,8 @@ Then, you can define quotas on this set:
 * max RAM
 * max disk usage
 
+> Note: Snapshotting a VM within a self-service will use the quota from the resource set. The same rule applies for backups and replication.  
+
 When you click on create, you can see the resource set and remove or edit it:
 
 ![](https://xen-orchestra.com/blog/content/images/2016/02/selfservice_recap_quotas.png)


### PR DESCRIPTION
Adding a note explaining that creating a snapshot within a self service VM will use the resources in the set. regarding issue #2420